### PR TITLE
implement get_person_by_prox_rfid

### DIFF
--- a/restclients/exceptions.py
+++ b/restclients/exceptions.py
@@ -58,6 +58,11 @@ class InvalidIdCardPhotoSize(Exception):
     pass
 
 
+class InvalidProxRFID(Exception):
+    """Exception for invalid rfid."""
+    pass
+
+
 class InvalidEndpointProtocol(Exception):
     """Exception for invalid endpoint protocol."""
     pass

--- a/restclients/pws.py
+++ b/restclients/pws.py
@@ -5,7 +5,7 @@ This is the interface for interacting with the Person Web Service.
 from restclients.dao import PWS_DAO
 from restclients.exceptions import InvalidRegID, InvalidNetID,\
     InvalidEmployeeID, InvalidStudentNumber, InvalidIdCardPhotoSize,\
-    DataFailureException
+    InvalidProxRFID, DataFailureException
 from restclients.models.sws import Person, Entity
 from StringIO import StringIO
 from urllib import urlencode
@@ -15,6 +15,7 @@ import re
 
 PERSON_PREFIX = '/identity/v1/person'
 ENTITY_PREFIX = '/identity/v1/entity'
+CARD_PREFIX = '/idcard/v1/card'
 
 
 class PWS(object):
@@ -31,6 +32,7 @@ class PWS(object):
                                                 re.I)
         self._re_employee_id = re.compile(r'^\d{9}$')
         self._re_student_number = re.compile(r'^\d{7}$')
+        self._re_prox_rfid = re.compile(r'^\d{16}$')
 
     def get_person_by_regid(self, regid):
         """
@@ -114,6 +116,30 @@ class PWS(object):
             raise DataFailureException(url, 404, "No person found")
 
         regid = data["Persons"][0]["PersonURI"]["UWRegID"]
+        return self.get_person_by_regid(regid)
+
+    def get_person_by_prox_rfid(self, prox_rfid):
+        """
+        Returns the person for the given rfid.  If the rfid isn't found, or if
+        there is an error communicating with the IdCard WS, a
+        DataFailureException will be thrown.
+        """
+        if not self.valid_prox_rfid(prox_rfid):
+            raise InvalidProxRFID(prox_rfid)
+
+        dao = PWS_DAO()
+        url = "%s.json?%s" % (CARD_PREFIX,
+                              urlencode({"prox_rfid": prox_rfid}))
+        response = dao.getURL(url, {"Accept": "application/json"})
+
+        if response.status != 200:
+            raise DataFailureException(url, response.status, response.data)
+
+        data = json.loads(response.data)
+        if not len(data["Cards"]):
+            raise DataFailureException(url, 404, "No card found")
+
+        regid = data["Cards"][0]["RegID"]
         return self.get_person_by_regid(regid)
 
     def get_entity_by_regid(self, regid):
@@ -218,6 +244,9 @@ class PWS(object):
     def valid_student_number(self, student_number):
         return True if (
             self._re_student_number.match(str(student_number))) else False
+
+    def valid_prox_rfid(self, prox_rfid):
+        return True if self._re_prox_rfid.match(str(prox_rfid)) else False
 
     def _person_from_json(self, data):
         """

--- a/restclients/resources/pws/file/idcard/v1/card.json_prox_rfid_1223221621633408
+++ b/restclients/resources/pws/file/idcard/v1/card.json_prox_rfid_1223221621633408
@@ -1,0 +1,13 @@
+{
+    "Cards": [
+        {
+            "RegID": "9136CCB8F66711D5BE060004AC494FFE"
+        }
+    ],
+    "Current": {
+        "Href": "\/idcard\/v1\/card.json?mag_strip_code=&prox_rfid=1223221621633408",
+        "MagStripCode": null,
+        "ProxRFID": "1223221621633408"
+    },
+    "TotalCount":1
+}

--- a/restclients/test/pws/card.py
+++ b/restclients/test/pws/card.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+from restclients.pws import PWS
+from restclients.exceptions import DataFailureException, InvalidProxRFID
+from restclients.test import fdao_pws_override
+
+
+@fdao_pws_override
+class IdCardTestCard(TestCase):
+
+    def test_by_rfid(self):
+        pws = PWS()
+        person = pws.get_person_by_prox_rfid('1223221621633408')
+        self.assertEquals(person.uwnetid, 'javerage', "Correct netid")
+        self.assertEquals(person.uwregid,
+                          '9136CCB8F66711D5BE060004AC494FFE', "Correct regid")
+
+        # Valid non-existent RFID
+        self.assertRaises(DataFailureException,
+                          pws.get_person_by_prox_rfid,
+                          '1234567890123456')
+
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid,
+                          '123456')
+
+    def test_bad_prox_rfids(self):
+        pws = PWS()
+        self.assertRaises(InvalidProxRFID, pws.get_person_by_prox_rfid, "")
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid, " ")
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid, "A")
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid, "123456789012345N")
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid, "1")
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid, "1234567890")

--- a/restclients/test/pws/photo.py
+++ b/restclients/test/pws/photo.py
@@ -7,7 +7,7 @@ from restclients.test import fdao_pws_override
 
 
 @fdao_pws_override
-class TestIdCardPhoto(TestCase):
+class IdCardTestPhoto(TestCase):
 
     def test_actas(self):
         user = Person(uwnetid="bill")

--- a/restclients/tests.py
+++ b/restclients/tests.py
@@ -46,7 +46,8 @@ from restclients.test.sws.dates import SWSTestDates
 
 from restclients.test.pws.person import PWSTestPersonData
 from restclients.test.pws.entity import PWSTestEntityData
-from restclients.test.pws.idcard import TestIdCardPhoto
+from restclients.test.pws.card import IdCardTestCard
+from restclients.test.pws.photo import IdCardTestPhoto
 from restclients.test.pws.err404.dao import PWSTestDAO404
 from restclients.test.pws.err404.pws import PWSTest404
 from restclients.test.pws.err500.dao import PWSTestDAO500


### PR DESCRIPTION
This implements use of the new card resource of the IdCard web service: https://wiki.cac.washington.edu/display/idcardws/Card+Search+Resource

Implementation mirrors the searches by employee_id and student_number pretty exactly, and the idcard web service had already been mingled in with pws.py via the photo endpoint, so I thought this might be an acceptable addition.