### PR TITLE
implement get_person_by_prox_rfid

### DIFF
--- a/restclients/exceptions.py
+++ b/restclients/exceptions.py
@@ -58,6 +58,11 @@ class InvalidIdCardPhotoSize(Exception):
     pass
 
 
+class InvalidProxRFID(Exception):
+    """Exception for invalid rfid."""
+    pass
+
+
 class InvalidEndpointProtocol(Exception):
     """Exception for invalid endpoint protocol."""
     pass

--- a/restclients/resources/pws/file/idcard/v1/card.json_prox_rfid_1223221621633408
+++ b/restclients/resources/pws/file/idcard/v1/card.json_prox_rfid_1223221621633408
@@ -1,0 +1,13 @@
+{
+    "Cards": [
+        {
+            "RegID": "9136CCB8F66711D5BE060004AC494FFE"
+        }
+    ],
+    "Current": {
+        "Href": "\/idcard\/v1\/card.json?mag_strip_code=&prox_rfid=1223221621633408",
+        "MagStripCode": null,
+        "ProxRFID": "1223221621633408"
+    },
+    "TotalCount":1
+}

--- a/restclients/test/pws/card.py
+++ b/restclients/test/pws/card.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+from restclients.pws import PWS
+from restclients.exceptions import DataFailureException, InvalidProxRFID
+from restclients.test import fdao_pws_override
+
+
+@fdao_pws_override
+class IdCardTestCard(TestCase):
+
+    def test_by_rfid(self):
+        pws = PWS()
+        person = pws.get_person_by_prox_rfid('1223221621633408')
+        self.assertEquals(person.uwnetid, 'javerage', "Correct netid")
+        self.assertEquals(person.uwregid,
+                          '9136CCB8F66711D5BE060004AC494FFE', "Correct regid")
+
+        # Valid non-existent RFID
+        self.assertRaises(DataFailureException,
+                          pws.get_person_by_prox_rfid,
+                          '1234567890123456')
+
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid,
+                          '123456')
+
+    def test_bad_prox_rfids(self):
+        pws = PWS()
+        self.assertRaises(InvalidProxRFID, pws.get_person_by_prox_rfid, "")
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid, " ")
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid, "A")
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid, "123456789012345N")
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid, "1")
+        self.assertRaises(InvalidProxRFID,
+                          pws.get_person_by_prox_rfid, "1234567890")

--- a/restclients/test/pws/photo.py
+++ b/restclients/test/pws/photo.py
@@ -7,7 +7,7 @@ from restclients.test import fdao_pws_override
 
 
 @fdao_pws_override
-class TestIdCardPhoto(TestCase):
+class IdCardTestPhoto(TestCase):
 
     def test_actas(self):
         user = Person(uwnetid="bill")

--- a/restclients/tests.py
+++ b/restclients/tests.py
@@ -50,7 +50,8 @@ from restclients.test.sws.dates import SWSTestDates
 
 from restclients.test.pws.person import PWSTestPersonData
 from restclients.test.pws.entity import PWSTestEntityData
-from restclients.test.pws.idcard import TestIdCardPhoto
+from restclients.test.pws.card import IdCardTestCard
+from restclients.test.pws.photo import IdCardTestPhoto
 from restclients.test.pws.err404.dao import PWSTestDAO404
 from restclients.test.pws.err404.pws import PWSTest404
 from restclients.test.pws.err500.dao import PWSTestDAO500


### PR DESCRIPTION
This implements use of the new card resource of the IdCard web service: https://wiki.cac.washington.edu/display/idcardws/Card+Search+Resource

Implementation mirrors the searches by employee_id and student_number pretty exactly, and the idcard web service had already been mingled in with pws.py via the photo endpoint, so I thought this might be an acceptable addition.